### PR TITLE
Add Payout status and cancel, Partner balance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.sw?
+.ruby-gemset

--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ response = Payoneer::Payout.create(
 )
 
 p 'Payout created!' if response.ok?
+
+# Status of a Payout
+
+response = Payoneer::Payout.status(payee_id: 'payee_1', payment_id: 'payment_1')
+p response.body
+=> 'Payment completed'
+
+# Cancel a Payout
+response = Payoneer::Payout.cancel('payment_1') # payment_id
+p response.body
+=> { 'PaymentID' => 'payment1',
+     'Result' => '000',
+     'Amount' => '5.00',
+     'Curr' => 'USD',
+     'Description' => 'Long description of the payout' }
+
+# Balance of the partner
+response = Payoneer::Partner.balance
+p response.body
+=> { 'FeesDue' => '110.45',
+     'AccountBalance' => '222.33',
+     'Curr' => 'USD' }
+
 ```
 
 ## Development

--- a/lib/payoneer.rb
+++ b/lib/payoneer.rb
@@ -15,6 +15,7 @@ require 'payoneer/response'
 require 'payoneer/system'
 require 'payoneer/payee'
 require 'payoneer/payout'
+require 'payoneer/partner'
 
 # Errors
 require 'payoneer/errors/unexpected_response_error'

--- a/lib/payoneer/partner.rb
+++ b/lib/payoneer/partner.rb
@@ -1,0 +1,21 @@
+module Payoneer
+  class Partner
+    ACCOUNT_DETAILS_API_METHOD_NAME = 'GetAccountDetails'
+
+    def self.balance
+      response = Payoneer.make_api_request(ACCOUNT_DETAILS_API_METHOD_NAME)
+
+      if success?(response)
+        Response.new_ok_response(response)
+      else
+        Response.new(response['Code'], response['Error'])
+      end
+    end
+
+    private
+
+    def self.success?(response)
+      !response.has_key?('Code')
+    end
+  end
+end

--- a/lib/payoneer/payout.rb
+++ b/lib/payoneer/payout.rb
@@ -28,7 +28,17 @@ module Payoneer
       response = Payoneer.make_api_request(GET_PAYMENT_STATUS_API_METHOD_NAME,
                                            payoneer_params)
 
-      Response.new(response['Result'], response['Status'])
+      if success?(response)
+        Response.new(response['Result'], response['Status'])
+      else
+        Response.new(response['Result'], response['Description'])
+      end
+    end
+
+    private
+
+    def self.success?(response)
+      response['Result'] == '000'
     end
   end
 end

--- a/lib/payoneer/payout.rb
+++ b/lib/payoneer/payout.rb
@@ -29,7 +29,7 @@ module Payoneer
                                            payoneer_params)
 
       if success?(response)
-        Response.new(response['Result'], response['Status'])
+        Response.new_ok_response(response['Status'])
       else
         Response.new(response['Result'], response['Description'])
       end

--- a/lib/payoneer/payout.rb
+++ b/lib/payoneer/payout.rb
@@ -2,6 +2,7 @@ module Payoneer
   class Payout
     CREATE_PAYOUT_API_METHOD_NAME = 'PerformPayoutPayment'
     GET_PAYMENT_STATUS_API_METHOD_NAME = 'GetPaymentStatus'
+    CANCEL_PAYMENT_API_METHOD_NAME = 'CancelPayment'
 
     def self.create(program_id:, payment_id:, payee_id:, amount:, description:, payment_date: Time.now, currency: 'USD')
       payoneer_params = {
@@ -30,6 +31,19 @@ module Payoneer
 
       if success?(response)
         Response.new_ok_response(response['Status'])
+      else
+        Response.new(response['Result'], response['Description'])
+      end
+    end
+
+    def self.cancel(payment_id)
+      payoneer_params = { p4: payment_id }
+
+      response = Payoneer.make_api_request(CANCEL_PAYMENT_API_METHOD_NAME,
+                                           payoneer_params)
+
+      if success?(response)
+        Response.new_ok_response(response)
       else
         Response.new(response['Result'], response['Description'])
       end

--- a/lib/payoneer/payout.rb
+++ b/lib/payoneer/payout.rb
@@ -1,6 +1,7 @@
 module Payoneer
   class Payout
     CREATE_PAYOUT_API_METHOD_NAME = 'PerformPayoutPayment'
+    GET_PAYMENT_STATUS_API_METHOD_NAME = 'GetPaymentStatus'
 
     def self.create(program_id:, payment_id:, payee_id:, amount:, description:, payment_date: Time.now, currency: 'USD')
       payoneer_params = {
@@ -16,6 +17,18 @@ module Payoneer
       response = Payoneer.make_api_request(CREATE_PAYOUT_API_METHOD_NAME, payoneer_params)
 
       Response.new(response['Status'], response['Description'])
+    end
+
+    def self.status(payee_id:, payment_id:)
+      payoneer_params = {
+        p4: payee_id,
+        p5: payment_id
+      }
+
+      response = Payoneer.make_api_request(GET_PAYMENT_STATUS_API_METHOD_NAME,
+                                           payoneer_params)
+
+      Response.new(response['Result'], response['Status'])
     end
   end
 end

--- a/spec/payoneer/partner_spec.rb
+++ b/spec/payoneer/partner_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Payoneer::Partner do
+  describe '.balance' do
+    context 'when success response' do
+      let(:success_response) {
+        {
+          'FeesDue' => '110.45',
+          'AccountBalance' => '222.33',
+          'Curr' => 'USD'
+        }
+      }
+
+      it 'returns a response with hash' do
+        expect(Payoneer).to receive(:make_api_request).
+          with('GetAccountDetails') { success_response }
+
+        expected_response = Payoneer::Response.new('000', success_response)
+        actual_response = described_class.balance
+
+        expect(actual_response).to eq(expected_response)
+        expect(actual_response.ok?).to be true
+      end
+    end
+
+    context 'when error response' do
+      let(:error_response) {
+        {
+          'Code' => '006',
+          'Error' => 'Internal Error'
+        }
+      }
+
+      it 'returns a response with error description' do
+        expect(Payoneer).to receive(:make_api_request).
+          with('GetAccountDetails') { error_response }
+
+        expected_response = Payoneer::Response.new('006', 'Internal Error')
+        actual_response = described_class.balance
+
+        expect(actual_response).to eq(expected_response)
+        expect(actual_response.ok?).to be false
+      end
+    end
+  end
+end

--- a/spec/payoneer/payout_spec.rb
+++ b/spec/payoneer/payout_spec.rb
@@ -65,4 +65,47 @@ describe Payoneer::Payout do
       end
     end
   end
+
+  describe '.status' do
+    let(:params) {
+      {
+        payee_id: 'payee123',
+        payment_id: 'payment1'
+      }
+    }
+
+    let(:payoneer_params) {
+      {
+        p4: 'payee123',
+        p5: 'payment1'
+      }
+    }
+
+    context 'when success response' do
+      let(:success_response) {
+        {
+          "PaymentID" => "payment1",
+          "Result" => "000",
+          "Description" => "",
+          "PaymentDate" => "04/30/2015 03:33:44",
+          "Amount" => "5.00",
+          "Status" => "Payment completed",
+          "LoadDate" => "04/30/2015 03:33:44",
+          "Curr" => "USD"
+        }
+      }
+
+      context 'when payment status is completed' do
+        it 'returns a response with Payment completed' do
+          expect(Payoneer).to receive(:make_api_request).
+            with('GetPaymentStatus', payoneer_params) { success_response }
+
+          expected_response = Payoneer::Response.new('000', 'Payment completed')
+          actual_response = described_class.status(params)
+
+          expect(actual_response).to eq(expected_response)
+        end
+      end
+    end
+  end
 end

--- a/spec/payoneer/payout_spec.rb
+++ b/spec/payoneer/payout_spec.rb
@@ -130,4 +130,42 @@ describe Payoneer::Payout do
       end
     end
   end
+
+  describe '.cancel' do
+    let(:payment_id) { 'payment1' }
+
+    let(:payoneer_params) {
+      {
+        p4: 'payment1'
+      }
+    }
+
+    context 'when success response' do
+      let(:success_response) {
+        {
+          'PaymentID' => 'payment1',
+          'Result' => '000',
+          'Amount' => '5.00',
+          'Curr' => 'USD',
+          'Description' => 'For your wonderful campaign'
+        }
+      }
+
+      it 'returns a response with hash' do
+        expect(Payoneer).to receive(:make_api_request).
+          with('CancelPayment', payoneer_params) { success_response }
+
+        expected_response = Payoneer::Response.new('000', success_response)
+        actual_response = described_class.cancel(payment_id)
+
+        expect(actual_response).to eq(expected_response)
+        expect(actual_response.ok?).to be true
+      end
+    end
+
+    pending 'when error response'
+    # Documentation seems not accurate about this case,
+    # need to test in true.
+
+  end
 end

--- a/spec/payoneer/payout_spec.rb
+++ b/spec/payoneer/payout_spec.rb
@@ -95,12 +95,32 @@ describe Payoneer::Payout do
         }
       }
 
-      context 'when payment status is completed' do
-        it 'returns a response with Payment completed' do
-          expect(Payoneer).to receive(:make_api_request).
-            with('GetPaymentStatus', payoneer_params) { success_response }
+      it 'returns a response with status' do
+        expect(Payoneer).to receive(:make_api_request).
+          with('GetPaymentStatus', payoneer_params) { success_response }
 
-          expected_response = Payoneer::Response.new('000', 'Payment completed')
+        expected_response = Payoneer::Response.new('000', 'Payment completed')
+        actual_response = described_class.status(params)
+
+        expect(actual_response).to eq(expected_response)
+      end
+    end
+
+    context 'when failed response' do
+      context 'when invalid payment_id' do
+        let(:error_response) {
+          {
+            "Result" => "PE1026",
+            "Description" => "Invalid PaymentID or PayeeID"
+          }
+        }
+
+        it 'returns an error response with description' do
+          expect(Payoneer).to receive(:make_api_request).
+            with('GetPaymentStatus', payoneer_params) { error_response }
+
+          expected_response =
+            Payoneer::Response.new('PE1026', 'Invalid PaymentID or PayeeID')
           actual_response = described_class.status(params)
 
           expect(actual_response).to eq(expected_response)

--- a/spec/payoneer/payout_spec.rb
+++ b/spec/payoneer/payout_spec.rb
@@ -103,6 +103,7 @@ describe Payoneer::Payout do
         actual_response = described_class.status(params)
 
         expect(actual_response).to eq(expected_response)
+        expect(actual_response.ok?).to be true
       end
     end
 
@@ -124,6 +125,7 @@ describe Payoneer::Payout do
           actual_response = described_class.status(params)
 
           expect(actual_response).to eq(expected_response)
+        expect(actual_response.ok?).to be false
         end
       end
     end

--- a/spec/payoneer/payout_spec.rb
+++ b/spec/payoneer/payout_spec.rb
@@ -163,9 +163,25 @@ describe Payoneer::Payout do
       end
     end
 
-    pending 'when error response'
-    # Documentation seems not accurate about this case,
-    # need to test in true.
+    context 'when error response' do
+      let(:error_response) {
+        {
+          'PaymentID' => 'payment1',
+          'Result' => 'PE1026',
+          'Description' => 'Invalid paymentId'
+        }
+      }
 
+      it 'returns an error response with description' do
+        expect(Payoneer).to receive(:make_api_request).
+          with('CancelPayment', payoneer_params) { error_response }
+
+        expected_response = Payoneer::Response.new('PE1026', 'Invalid paymentId')
+        actual_response = described_class.cancel(payment_id)
+
+        expect(actual_response).to eq(expected_response)
+        expect(actual_response.ok?).to be false
+      end
+    end
   end
 end

--- a/spec/payoneer/payout_spec.rb
+++ b/spec/payoneer/payout_spec.rb
@@ -84,14 +84,14 @@ describe Payoneer::Payout do
     context 'when success response' do
       let(:success_response) {
         {
-          "PaymentID" => "payment1",
-          "Result" => "000",
-          "Description" => "",
-          "PaymentDate" => "04/30/2015 03:33:44",
-          "Amount" => "5.00",
-          "Status" => "Payment completed",
-          "LoadDate" => "04/30/2015 03:33:44",
-          "Curr" => "USD"
+          'PaymentID' => 'payment1',
+          'Result' => '000',
+          'Description' => '',
+          'PaymentDate' => '04/30/2015 03:33:44',
+          'Amount' => '5.00',
+          'Status' => 'Payment completed',
+          'LoadDate' => '04/30/2015 03:33:44',
+          'Curr' => 'USD'
         }
       }
 
@@ -111,8 +111,8 @@ describe Payoneer::Payout do
       context 'when invalid payment_id' do
         let(:error_response) {
           {
-            "Result" => "PE1026",
-            "Description" => "Invalid PaymentID or PayeeID"
+            'Result' => 'PE1026',
+            'Description' => 'Invalid PaymentID or PayeeID'
           }
         }
 
@@ -125,7 +125,7 @@ describe Payoneer::Payout do
           actual_response = described_class.status(params)
 
           expect(actual_response).to eq(expected_response)
-        expect(actual_response.ok?).to be false
+          expect(actual_response.ok?).to be false
         end
       end
     end


### PR DESCRIPTION
Hi,

To cover better the Payoneer API, I have added new methods to `Payout`:
- `status` to get the status of payout
- `cancel` to cancel a payout

And a new class `Partner` with a method `balance` to get the current balance of the partner.
